### PR TITLE
add QtGui to dependencies

### DIFF
--- a/BUILD.qt
+++ b/BUILD.qt
@@ -19,3 +19,13 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+cc_library(
+    name = "qt_gui",
+    hdrs = glob(["QtGui/**"]),
+    includes = ["."],
+    deps = [":qt_core"],
+    linkopts = [
+        "-lQt5Gui",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/hello_world/BUILD
+++ b/hello_world/BUILD
@@ -22,6 +22,7 @@ qt_cc_library(
     deps = [
         "@qt//:qt_core",
         "@qt//:qt_widgets",
+        "@qt//:qt_gui",
     ],
     ui = "mainwindow.ui",
     ui_deps = [


### PR DESCRIPTION
Without the addition of QtGui, compilation fails with the following error:

  external/qt/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qwidget.h:45:10:
  fatal error: 'QtGui/qwindowdefs.h' file not found

Qt version is 5.3.2 from Debian Stable.

Signed-off-by: Alison Chaiken <alison@peloton-tech.com>