### PR TITLE
build rules: moc: force include generation

### DIFF
--- a/tools/build_rules/qt.bzl
+++ b/tools/build_rules/qt.bzl
@@ -37,7 +37,8 @@ def qt_cc_library(name, src, hdr, deps, ui=None, ui_deps=None, **kwargs):
       name = "%s_moc" % name,
       srcs = [hdr],
       outs = ["moc_%s.cpp" % name],
-      cmd = "/usr/bin/moc $(locations %s) -o $@" % hdr,
+      cmd =  "/usr/bin/moc $(location %s) -o $@ -f'%s'" \
+        % (hdr, '%s/%s' % (PACKAGE_NAME, hdr)),
   )
   srcs = [src, ":%s_moc" % name]
 


### PR DESCRIPTION
Bazel version 201611071351+5a614b8 fails on the previous version of
the qt.bzl rules for x86_64 architecture with the GCC compiler.  The
problem is due to the failure of the MOC to incorporate a resolvable
header path in the generated code.  Adding the '-f' option to the MOC
invocation resolves the problem.  The new version of the rules works
also with Clang and ARM-HF builds with the Linaro compiler.

Tested-by: Alison Chaiken <alison@peloton-tech.com>
Signed-off-by: Alison Chaiken <alison@peloton-tech.com>