### PR TITLE
build_rules: Qt: add ability to process normal headers

### DIFF
--- a/hello_world/BUILD
+++ b/hello_world/BUILD
@@ -16,6 +16,10 @@ qt_cc_library(
     name = "mainwindow",
     src = "mainwindow.cpp",
     hdr = "mainwindow.h",
+    normal_hdrs = [
+        'test_header.h',
+        'test_header2.h',
+    ],
     copts = [
         '-fpic',
     ],

--- a/hello_world/test_header.h
+++ b/hello_world/test_header.h
@@ -1,0 +1,9 @@
+#ifndef BUILD_TESTS_QT5_TEST_HEADER_H
+#define BUILD_TESTS_QT5_TEST_HEADER_H
+
+// Nonsense to test ability of qt_cc_library to include
+// headers which are not processed by Qt's MOC
+
+#define PIE 971
+
+#endif // BUILD_TESTS_QT5_TEST_HEADER_H

--- a/hello_world/test_header2.h
+++ b/hello_world/test_header2.h
@@ -1,0 +1,8 @@
+#ifndef BUILD_TESTS_QT5_TEST_HEADER2_H
+#define BUILD_TESTS_QT5_TEST_HEADER2_H
+
+// Second nonsense header to test multiplicity.
+
+#define FOO 123
+
+#endif // BUILD_TESTS_QT5_TEST_HEADER2_H

--- a/tools/build_rules/qt.bzl
+++ b/tools/build_rules/qt.bzl
@@ -19,7 +19,8 @@ def qt_ui_library(name, ui, deps):
       deps = deps,
   )
 
-def qt_cc_library(name, src, hdr, deps, ui=None, ui_deps=None, **kwargs):
+def qt_cc_library(name, src, hdr, normal_hdrs=[], deps=None, ui=None,
+                  ui_deps=None, **kwargs):
   """Compiles a QT library and generates the MOC for it.
 
   If a UI file is provided, then it is also compiled with UIC.
@@ -27,7 +28,8 @@ def qt_cc_library(name, src, hdr, deps, ui=None, ui_deps=None, **kwargs):
   Args:
     name: A name for the rule.
     src: The cpp file to compile.
-    hdr: The header file corresponding to the src.
+    hdr: The single header file that the MOC compiles to src.
+    normal_hdrs: Headers which are not sources for generated code.
     deps: cc_library dependencies for the library.
     ui: If provided, a UI file to compile with UIC.
     ui_deps: Dependencies for the UI file.
@@ -46,10 +48,12 @@ def qt_cc_library(name, src, hdr, deps, ui=None, ui_deps=None, **kwargs):
     qt_ui_library("%s_ui" % name, ui, deps=ui_deps)
     deps.append("%s_ui" % name)
 
+  hdrs = [hdr] + normal_hdrs
+
   native.cc_library(
       name = name,
       srcs = srcs,
-      hdrs = [hdr],
+      hdrs = hdrs,
       deps = deps,
       **kwargs
   )


### PR DESCRIPTION
Extend the upstream qt.bzl build rules to permit inclusion of headers
which are not processed by Qt's MOC.  Add trivial headers to the
qt5_build test in order to confirm that the rule extension works.

Signed-off-by: Alison Chaiken <alison@peloton-tech.com>