### PR TITLE
Remove absolute path for uic/moc

### DIFF
--- a/tools/build_rules/qt.bzl
+++ b/tools/build_rules/qt.bzl
@@ -10,7 +10,7 @@ def qt_ui_library(name, ui, deps):
       name = "%s_uic" % name,
       srcs = [ui],
       outs = ["ui_%s.h" % ui.split('.')[0]],
-      cmd = "/usr/bin/uic $(locations %s) -o $@" % ui,
+      cmd = "uic $(locations %s) -o $@" % ui,
   )
 
   native.cc_library(
@@ -39,7 +39,7 @@ def qt_cc_library(name, src, hdr, normal_hdrs=[], deps=None, ui=None,
       name = "%s_moc" % name,
       srcs = [hdr],
       outs = ["moc_%s.cpp" % name],
-      cmd =  "/usr/bin/moc $(location %s) -o $@ -f'%s'" \
+      cmd =  "moc $(location %s) -o $@ -f'%s'" \
         % (hdr, '%s/%s' % (PACKAGE_NAME, hdr)),
   )
   srcs = [src, ":%s_moc" % name]


### PR DESCRIPTION
Hi,

Thank you very much for your work, I was able to successfully  compile the "hello_world:main" target.

The only trouble I had is that I have several Qt versions on my computer (Linux/Debian distro) and your genrules use absolute path (/usr/bin/) for the uic and moc tools. I think this is problematic when you want to use the PATH environment variable (like in my case).

IMHO this would be simpler and better to simply remove this /usr/bin/ absolute path. 

- Vincent