### PR TITLE
Removed deprecated PACKAGE_NAME global in favor of native.package_nam…

### DIFF
--- a/tools/build_rules/qt.bzl
+++ b/tools/build_rules/qt.bzl
@@ -40,7 +40,7 @@ def qt_cc_library(name, src, hdr, normal_hdrs=[], deps=None, ui=None,
       srcs = [hdr],
       outs = ["moc_%s.cpp" % name],
       cmd =  "moc $(location %s) -o $@ -f'%s'" \
-        % (hdr, '%s/%s' % (PACKAGE_NAME, hdr)),
+        % (hdr, '%s/%s' % (native.package_name(), hdr)),
   )
   srcs = [src, ":%s_moc" % name]
 


### PR DESCRIPTION
…e() for null case